### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <uses-feature
         android:name="android.hardware.bluetooth"


### PR DESCRIPTION
On my Nexus 5 (Android 6.0) Blue hunter isn't getting any remote devices on discovery.   

According to this: https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html

To make Blue Hunter working under API Level 23 (Android 6.0) the app must now have the ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION permissions.
